### PR TITLE
Bug fixes for Craft 4

### DIFF
--- a/src/DocumentSearch.php
+++ b/src/DocumentSearch.php
@@ -36,6 +36,8 @@ use yii\base\Event;
 class DocumentSearch extends Plugin
 {
 
+    public bool $hasCpSettings = true;
+
     /**
      * @inheritdoc
      */

--- a/src/console/controllers/ParseDocumentsController.php
+++ b/src/console/controllers/ParseDocumentsController.php
@@ -39,7 +39,7 @@ class ParseDocumentsController extends Controller
         $errorCount = 0;
         foreach ($volumes as $volume) {
             $assetQuery = new AssetQuery(Asset::class);
-            $assetQuery->volumeId = $volume;
+            $assetQuery->uid = $volume;
 
             $assets = $assetQuery->all();
             Console::startProgress(0, count($assets));


### PR DESCRIPTION
I discovered two issues when using the plugin on Craft 4. 

1. The CP settings panel was not appearing for me
2. When running the index command from the console, was unable to loop through the volumes properly.

